### PR TITLE
Capture and handle HTTP errors

### DIFF
--- a/assets/src/components/QueryForm.vue
+++ b/assets/src/components/QueryForm.vue
@@ -41,7 +41,7 @@ export default {
       threshold: "0.5"
     };
   },
-  emits: ["query-results"],
+  emits: ["query-begin", "query-results"],
   components: {
     ArticleTitlePicker,
     LanguageSelector,
@@ -49,6 +49,8 @@ export default {
   },
   methods: {
     submit: async function() {
+      this.$emit("query-begin");
+
       if (this.lang && !this.title) {
         this.title = await getRandomTitle(this.lang);
       }

--- a/assets/src/components/ToolHolder.vue
+++ b/assets/src/components/ToolHolder.vue
@@ -6,7 +6,14 @@
 
     <section id="topic-models" class="boxwidth--1-1 padded--left padded--right">
       <main id="tool_main">
-        <query-form @query-results="result" />
+        <div v-if="this.error" class="error">
+          <span class="message">Your query failed:</span>
+          <span class="raw">{{ this.error.message }}</span>
+        </div>
+        <query-form
+          @query-begin="this.error = null"
+          @query-results="result"
+        />
         <results-table
           v-if="this.results"
           :response="this.results"
@@ -32,6 +39,7 @@ export default {
   },
   data: function() {
     return {
+      error: null,
       results: null,
       title: null
     };
@@ -41,6 +49,11 @@ export default {
       this.title = title;
       this.results = results;
     }
+  },
+  errorCaptured(err) {
+    this.error = err;
+    this.results = null;
+    return false;
   }
 };
 </script>
@@ -470,6 +483,23 @@ export default {
   .text > ul + *,
   .text > ol + * {
     margin-top: 4.2rem;
+  }
+
+  .error {
+    color: #d33;
+    border: 1px solid #d33;
+    background-color: #fee7e6;
+    padding: 5px 12px;
+    margin: 1em;
+
+    .message {
+      font-weight: bold;
+    }
+
+    .raw {
+      margin-left: 1em;
+      font-style: italic;
+    }
   }
 
   @media all and (max-width: 1000px) {


### PR DESCRIPTION
When either API call fails with an exception, this handler will clear the
results component and display the error.

Clicking on Submit clears the error.  The `query-begin` event handler will
eventually be a good place to show spinners or otherwise give feedback after
submit.

Bug: T276840